### PR TITLE
Support Composite Relationships in Cassandra

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
 			"disableChoices": true,
 			"enableJsonType": true,
 			"enableArrayItemName": true,
-			"FEScriptCommentsSupported": true
+			"FEScriptCommentsSupported": true,
+			"relationships": {
+                		"compositeRelationships": true
+            		}
 		}
 	},
 	"description": "Hackolade plugin for Cassandra Datastax"


### PR DESCRIPTION
Cassandra uses compound keys for both "Partition Key" and "Cluster Column". This is highly required to be available. This Feature will satisfy one of the important  requirement of Cassandra developers.