### PR TITLE
HCK-5631: fix handle of multiple sample data for map properties

### DIFF
--- a/reverse_engineering/helpers/filterComplexUdt.js
+++ b/reverse_engineering/helpers/filterComplexUdt.js
@@ -24,6 +24,15 @@ module.exports = (_) => {
 
 		return handlerRecords.some(record => record === undefined) ? [] : handlerRecords; 
 	};
+
+	const handleMap = ({ properties, records }) => {
+		return Object.entries(properties).reduce((result, [propertyName, propertyValue]) => {
+			return {
+				...result,
+				[propertyName]: filterUdt(propertyValue?.properties, records?.[propertyName])
+			}
+		}, {});
+	};
 	
 	const filterUdt = (properties, records) => {
 		if (!_.isPlainObject(records)) {
@@ -45,7 +54,7 @@ module.exports = (_) => {
 			} else if (type === 'map' && propertyValue.properties) {
 				return {
 					...records,
-					[recordName]: filterUdt(propertyValue.properties, recordValues),
+					[recordName]: handleMap({ properties: propertyValue.properties, records: recordValues }),
 				}
 			}
 	

--- a/reverse_engineering/typesHelper.js
+++ b/reverse_engineering/typesHelper.js
@@ -51,7 +51,7 @@ module.exports = (_) => {
 		const keyData = (column.info || column.type.info)[0];
 		const valueData = (column.info || column.type.info)[1];
 		const handledKeyData = getColumnType(keyData);
-		const properties = getProperties(valueData, sample, udtHash);
+		const properties = getMapProperties({ valueData, sample, udtHash });
 		const keySubtype = handledKeyData.mode
 			? { keySubtype: handledKeyData.mode }
 			: {};
@@ -176,9 +176,23 @@ module.exports = (_) => {
 		const name = handledValueData.refName || defaultColumnName;
 
 		return {
-			[name]: _.omit(handledValueData, 'refName')
+			[name]: _.omit(handledValueData, "refName"),
 		};
 	};
+
+	const getMapProperties = ({ valueData, sample, udtHash }) => {
+    const properties = getProperties(valueData, sample, udtHash);
+    const propertyPairs = Object.entries(properties);
+    const uniqueProperties = _.uniqWith(
+      propertyPairs,
+      ([, propertyA], [, propertyB]) =>
+        propertyA.type === propertyB.type &&
+        propertyA.$ref === propertyB.$ref &&
+        propertyA.mode === propertyB.mode
+    );
+
+    return Object.fromEntries(uniqueProperties);
+  };
 
 	const getJsonType = (type) => {
 		switch (type) {

--- a/reverse_engineering/typesHelper.js
+++ b/reverse_engineering/typesHelper.js
@@ -176,23 +176,23 @@ module.exports = (_) => {
 		const name = handledValueData.refName || defaultColumnName;
 
 		return {
-			[name]: _.omit(handledValueData, "refName"),
+			[name]: _.omit(handledValueData, 'refName'),
 		};
 	};
 
 	const getMapProperties = ({ valueData, sample, udtHash }) => {
-    const properties = getProperties(valueData, sample, udtHash);
-    const propertyPairs = Object.entries(properties);
-    const uniqueProperties = _.uniqWith(
-      propertyPairs,
-      ([, propertyA], [, propertyB]) =>
-        propertyA.type === propertyB.type &&
-        propertyA.$ref === propertyB.$ref &&
-        propertyA.mode === propertyB.mode
-    );
+		const properties = getProperties(valueData, sample, udtHash);
+		const propertyPairs = Object.entries(properties);
+		const uniqueProperties = _.uniqWith(
+			propertyPairs,
+			([, propertyA], [, propertyB]) =>
+				propertyA.type === propertyB.type &&
+				propertyA.$ref === propertyB.$ref &&
+				propertyA.mode === propertyB.mode
+		);
 
-    return Object.fromEntries(uniqueProperties);
-  };
+		return Object.fromEntries(uniqueProperties);
+	};
 
 	const getJsonType = (type) => {
 		switch (type) {


### PR DESCRIPTION
Samples for `map<>` properties is combined into one object, which are then divided into separate fields by keys in the application.
It is necessary to unify them by type to get only one schema for the nested property