### PR TITLE
HCK-10586: add ipv6 escaping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"async": "3.2.6",
 				"cassandra-driver": "4.7.2",
 				"fast-xml-parser": "4.4.1",
+				"ip": "2.0.1",
 				"jks-js": "1.1.3",
 				"lodash": "4.17.21"
 			},
@@ -2694,6 +2695,12 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/ip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+			"license": "MIT"
 		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
         "cassandra-driver": "4.7.2",
         "fast-xml-parser": "4.4.1",
         "jks-js": "1.1.3",
-        "lodash": "4.17.21"
+        "lodash": "4.17.21",
+        "ip": "2.0.1"
     },
     "lint-staged": {
         "*.{js,json}": "prettier --write"

--- a/reverse_engineering/cassandraHelper.js
+++ b/reverse_engineering/cassandraHelper.js
@@ -7,6 +7,7 @@ const { getEntityLevelConfig } = require('../helpers/levelConfigHelper');
 const CassandraRetryPolicy = require('./cassandraRetryPolicy');
 const xmlParser = require('fast-xml-parser');
 const filterComplexUdt = require('./helpers/filterComplexUdt');
+const { escapeV6IpForURL } = require('./helpers/escapeV6IPForURL');
 
 const state = {
 	client: null,
@@ -270,7 +271,7 @@ module.exports = () => {
 				? { username: 'token', password: info.astraToken }
 				: { username: info.user, password: info.password };
 		const authProvider = new cassandra.auth.PlainTextAuthProvider(credentials.username, credentials.password);
-		const contactPoints = info.hosts.map(item => `${item.host}:${item.port}`);
+		const contactPoints = info.hosts.map(item => `${escapeV6IpForURL({ host: item.host })}:${item.port}`);
 		const readTimeout = validateRequestTimeout(info.requestTimeout, info.queryRequestTimeout);
 
 		return getSslOptions(info, app, logger).then(sslOptions => {

--- a/reverse_engineering/helpers/escapeV6IPForURL.js
+++ b/reverse_engineering/helpers/escapeV6IPForURL.js
@@ -1,28 +1,62 @@
 const ip = require('ip');
 
-//@see https://en.wikipedia.org/wiki/IPv6_address
-// Literal IPv6 addresses in resources (URLs):
-// ------------------------------------------------
-// Colon (:) characters in IPv6 addresses may conflict with the established syntax of resource identifiers,
-// such as URIs and URLs. The colon is conventionally used to terminate the host path before a port number.[10]
-// To alleviate this conflict, literal IPv6 addresses are enclosed in square brackets in such resource identifiers;
-// When the URL doesn't conatoin the port the notation is
-//      http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/
-// When the URL also contains a port number the notation is:
-//      https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/
+/**
+ * @see https://en.wikipedia.org/wiki/IPv6_address
+ * Literal IPv6 addresses in resources (URLs):
+------------------------------------------------
+ * Colon (:) characters in IPv6 addresses may conflict with the established syntax of resource identifiers,
+ * such as URIs and URLs. The colon is conventionally used to terminate the host path before a port number.[10]
+ * To alleviate this conflict, literal IPv6 addresses are enclosed in square brackets in such resource identifiers;
+ * When the URL doesn't conatoin the port the notation is http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/
+ * When the URL also contains a port number the notation is: https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/
+ *
+ * @param {{
+* 	host: string
+* }} param
+* @returns {string}
+*/
 function escapeV6IpForURL({ host }) {
-	// If the host is already URL compatible then the ip lib will return false
-	// > ip.isV6Format('[::1]')
-	// false
-	// If the host is a proper ipv6 ip then the `new URL(host)` will fail with Uncaught TypeError: Invalid URL
-	// code: 'ERR_INVALID_URL',
-	// !ip.isV4Format(host) check required because isV6Format returns true for ipv4 address because of backward compatibility
-
+	/**
+	 * If the host is already URL compatible then the ip lib will return false > ip.isV6Format('[::1]') false
+	 * If the host is a proper ipv6 ip then the `new URL(host)` will fail with Uncaught TypeError: Invalid URL code: 'ERR_INVALID_URL',
+	 * !ip.isV4Format(host) check required because isV6Format returns true for ipv4 address because of backward compatibility
+	 */
 	if (ip.isV6Format(host) && !ip.isV4Format(host)) {
 		return `[${host}]`;
 	}
 
-	return host;
+	const isUrlValid = isValidURL(host);
+	if (isUrlValid) {
+		return host;
+	}
+
+	const urlWithIpV6HostRegExp = new RegExp(/^http(s)?:\/\/(?<unescapedIpWithPort>([a-z0-9]{0,4}:?)+)/gim);
+	const { unescapedIpWithPort } = urlWithIpV6HostRegExp.exec(host)?.groups ?? {};
+
+	if (!unescapedIpWithPort) {
+		return host;
+	}
+
+	const separatedIpPortionsAndPort = unescapedIpWithPort.split(':');
+	const ipPortions = separatedIpPortionsAndPort.slice(0, separatedIpPortionsAndPort.length - 1);
+	const port = separatedIpPortionsAndPort.at(-1);
+	const escapedIpWithPort = `[${ipPortions.join(':')}]:${port}`;
+
+	return host.replace(unescapedIpWithPort, escapedIpWithPort);
+}
+
+/**
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isValidURL(url) {
+	try {
+		new URL(url);
+
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 module.exports = {

--- a/reverse_engineering/helpers/escapeV6IPForURL.js
+++ b/reverse_engineering/helpers/escapeV6IPForURL.js
@@ -1,0 +1,30 @@
+const ip = require('ip');
+
+//@see https://en.wikipedia.org/wiki/IPv6_address
+// Literal IPv6 addresses in resources (URLs):
+// ------------------------------------------------
+// Colon (:) characters in IPv6 addresses may conflict with the established syntax of resource identifiers,
+// such as URIs and URLs. The colon is conventionally used to terminate the host path before a port number.[10]
+// To alleviate this conflict, literal IPv6 addresses are enclosed in square brackets in such resource identifiers;
+// When the URL doesn't conatoin the port the notation is
+//      http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/
+// When the URL also contains a port number the notation is:
+//      https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/
+function escapeV6IpForURL({ host }) {
+	// If the host is already URL compatible then the ip lib will return false
+	// > ip.isV6Format('[::1]')
+	// false
+	// If the host is a proper ipv6 ip then the `new URL(host)` will fail with Uncaught TypeError: Invalid URL
+	// code: 'ERR_INVALID_URL',
+	// !ip.isV4Format(host) check required because isV6Format returns true for ipv4 address because of backward compatibility
+
+	if (ip.isV6Format(host) && !ip.isV4Format(host)) {
+		return `[${host}]`;
+	}
+
+	return host;
+}
+
+module.exports = {
+	escapeV6IpForURL,
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10586" title="HCK-10586" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-10586</a>  [Social Security Admin] Enclose ipv6 addresses in URLs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

add ipv6 escaping