### PR TITLE
HCK-14108: fix the generation of an alter script for partition keys if new values ​​do not exist

### DIFF
--- a/forward_engineering/helpers/updateHelpers/tableHelper.js
+++ b/forward_engineering/helpers/updateHelpers/tableHelper.js
@@ -121,12 +121,6 @@ const hydrateColumn = ({ tableName, keyspaceName, isOldModel, property, udtMap, 
 	};
 };
 
-const getTableParameter = (item, key) => {
-	const parameter = item?.role?.compMod?.[key];
-
-	return parameter?.new || item?.role?.[key];
-};
-
 const addToKeysHashType = (keysHash, keys) => {
 	return Object.entries(keysHash).reduce((keysHash, [id, key]) => {
 		const type = (keys.find(key => key.keyId === id) || {}).type;
@@ -217,8 +211,8 @@ const getAddTable = addTableData => {
 	}
 	let table = addTableData.item;
 	const data = addTableData.data;
-	const compositePartitionKey = getTableParameter(table, 'compositePartitionKey') || [];
-	const compositeClusteringKey = getTableParameter(table, 'compositeClusteringKey') || [];
+	const compositePartitionKey = table?.role?.compMod?.compositePartitionKey?.new || [];
+	const compositeClusteringKey = table?.role?.compMod?.compositeClusteringKey?.new || [];
 
 	const entityData = [
 		{
@@ -248,7 +242,6 @@ module.exports = {
 	getAdd,
 	hydrateColumn,
 	isTableChange,
-	getTableParameter,
 	addScriptToExistScripts,
 	getDeleteTableDto,
 	getAddTable,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14108" title="HCK-14108" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14108</a>  [Cassandra]: Fix altering partition keys if property no longer exist
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

If the new value doesn't exist in the comp mode, the keys must be empty. Taking the value from the `role` object is incorrect.