### PR TITLE
HCK-14108: fix added table keys generation

### DIFF
--- a/forward_engineering/helpers/updateHelpers/tableHelper.js
+++ b/forward_engineering/helpers/updateHelpers/tableHelper.js
@@ -121,6 +121,12 @@ const hydrateColumn = ({ tableName, keyspaceName, isOldModel, property, udtMap, 
 	};
 };
 
+const getTableParameter = (item, key) => {
+	const isCreated = item?.role?.compMod?.created;
+
+	return isCreated ? item?.role?.[key] : item?.role?.compMod?.[key]?.new;
+};
+
 const addToKeysHashType = (keysHash, keys) => {
 	return Object.entries(keysHash).reduce((keysHash, [id, key]) => {
 		const type = (keys.find(key => key.keyId === id) || {}).type;
@@ -211,8 +217,8 @@ const getAddTable = addTableData => {
 	}
 	let table = addTableData.item;
 	const data = addTableData.data;
-	const compositePartitionKey = table?.role?.compMod?.compositePartitionKey?.new || [];
-	const compositeClusteringKey = table?.role?.compMod?.compositeClusteringKey?.new || [];
+	const compositePartitionKey = getTableParameter(table, 'compositePartitionKey') || [];
+	const compositeClusteringKey = getTableParameter(table, 'compositeClusteringKey') || [];
 
 	const entityData = [
 		{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14108" title="HCK-14108" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14108</a>  [Cassandra]: Fix altering partition keys if property no longer exist
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

[Failed test](https://teamcity.hackolade.com/buildConfiguration/RunTests_RunFeatureTestsFeOnly/213264)

## Technical details

`getAddTable` function is used both to create a new table and to recreate a modified table, and partition/clustering keys can be located in different places in the comp mode for these two cases.